### PR TITLE
STEP 2 요구사항 구현

### DIFF
--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -8,6 +8,23 @@
 
 /* Begin PBXBuildFile section */
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
+		F47327D22B1589E3000849B1 /* IO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327D12B1589E3000849B1 /* IO.swift */; };
+		F47327D42B1589F1000849B1 /* Hand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327D32B1589F1000849B1 /* Hand.swift */; };
+		F47327E02B158A49000849B1 /* HandGameError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327DF2B158A49000849B1 /* HandGameError.swift */; };
+		F47327E22B158A5E000849B1 /* HandGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327E12B158A5E000849B1 /* HandGameApp.swift */; };
+		F47327E42B15C4F9000849B1 /* RPSPlayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327E32B15C4F9000849B1 /* RPSPlayable.swift */; };
+		F47327E62B15C7B8000849B1 /* RPSGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327E52B15C7B8000849B1 /* RPSGame.swift */; };
+		F47327EC2B160687000849B1 /* RPSGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327EB2B160687000849B1 /* RPSGesture.swift */; };
+		F47327F22B160737000849B1 /* UserPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327F12B160737000849B1 /* UserPlayer.swift */; };
+		F47327F42B160749000849B1 /* ComputerPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327F32B160749000849B1 /* ComputerPlayer.swift */; };
+		F47327F62B160B71000849B1 /* MJBGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327F52B160B71000849B1 /* MJBGame.swift */; };
+		F47327F82B160E21000849B1 /* MJBPlayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327F72B160E21000849B1 /* MJBPlayable.swift */; };
+		F47327FC2B1612B2000849B1 /* MJBGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327FB2B1612B2000849B1 /* MJBGesture.swift */; };
+		F47328002B16F0FD000849B1 /* RPSResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47327FF2B16F0FD000849B1 /* RPSResult.swift */; };
+		F47328022B16F114000849B1 /* MJBResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47328012B16F114000849B1 /* MJBResult.swift */; };
+		F47328042B16F128000849B1 /* RPSPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47328032B16F128000849B1 /* RPSPart.swift */; };
+		F47328062B16F13A000849B1 /* MJBPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47328052B16F13A000849B1 /* MJBPart.swift */; };
+		F473280C2B16F755000849B1 /* Console.swift in Sources */ = {isa = PBXBuildFile; fileRef = F473280B2B16F755000849B1 /* Console.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,6 +42,23 @@
 /* Begin PBXFileReference section */
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		F47327D12B1589E3000849B1 /* IO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IO.swift; sourceTree = "<group>"; };
+		F47327D32B1589F1000849B1 /* Hand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hand.swift; sourceTree = "<group>"; };
+		F47327DF2B158A49000849B1 /* HandGameError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandGameError.swift; sourceTree = "<group>"; };
+		F47327E12B158A5E000849B1 /* HandGameApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandGameApp.swift; sourceTree = "<group>"; };
+		F47327E32B15C4F9000849B1 /* RPSPlayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPSPlayable.swift; sourceTree = "<group>"; };
+		F47327E52B15C7B8000849B1 /* RPSGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPSGame.swift; sourceTree = "<group>"; };
+		F47327EB2B160687000849B1 /* RPSGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPSGesture.swift; sourceTree = "<group>"; };
+		F47327F12B160737000849B1 /* UserPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPlayer.swift; sourceTree = "<group>"; };
+		F47327F32B160749000849B1 /* ComputerPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputerPlayer.swift; sourceTree = "<group>"; };
+		F47327F52B160B71000849B1 /* MJBGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MJBGame.swift; sourceTree = "<group>"; };
+		F47327F72B160E21000849B1 /* MJBPlayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MJBPlayable.swift; sourceTree = "<group>"; };
+		F47327FB2B1612B2000849B1 /* MJBGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MJBGesture.swift; sourceTree = "<group>"; };
+		F47327FF2B16F0FD000849B1 /* RPSResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPSResult.swift; sourceTree = "<group>"; };
+		F47328012B16F114000849B1 /* MJBResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MJBResult.swift; sourceTree = "<group>"; };
+		F47328032B16F128000849B1 /* RPSPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPSPart.swift; sourceTree = "<group>"; };
+		F47328052B16F13A000849B1 /* MJBPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MJBPart.swift; sourceTree = "<group>"; };
+		F473280B2B16F755000849B1 /* Console.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Console.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,8 +92,65 @@
 			isa = PBXGroup;
 			children = (
 				C7ABA0E0254EA63000B2367D /* main.swift */,
+				F47327E12B158A5E000849B1 /* HandGameApp.swift */,
+				F47327DF2B158A49000849B1 /* HandGameError.swift */,
+				F47327D32B1589F1000849B1 /* Hand.swift */,
+				F473280D2B16F765000849B1 /* IO */,
+				F47328072B16F69F000849B1 /* Player */,
+				F47328092B16F6FA000849B1 /* Game */,
+				F47328082B16F6B7000849B1 /* Decision */,
+				F473280A2B16F707000849B1 /* Result */,
 			);
 			path = RockPaperScissors;
+			sourceTree = "<group>";
+		};
+		F47328072B16F69F000849B1 /* Player */ = {
+			isa = PBXGroup;
+			children = (
+				F47327E32B15C4F9000849B1 /* RPSPlayable.swift */,
+				F47327F72B160E21000849B1 /* MJBPlayable.swift */,
+				F47327F12B160737000849B1 /* UserPlayer.swift */,
+				F47327F32B160749000849B1 /* ComputerPlayer.swift */,
+			);
+			path = Player;
+			sourceTree = "<group>";
+		};
+		F47328082B16F6B7000849B1 /* Decision */ = {
+			isa = PBXGroup;
+			children = (
+				F47327EB2B160687000849B1 /* RPSGesture.swift */,
+				F47327FB2B1612B2000849B1 /* MJBGesture.swift */,
+			);
+			path = Decision;
+			sourceTree = "<group>";
+		};
+		F47328092B16F6FA000849B1 /* Game */ = {
+			isa = PBXGroup;
+			children = (
+				F47328032B16F128000849B1 /* RPSPart.swift */,
+				F47328052B16F13A000849B1 /* MJBPart.swift */,
+				F47327E52B15C7B8000849B1 /* RPSGame.swift */,
+				F47327F52B160B71000849B1 /* MJBGame.swift */,
+			);
+			path = Game;
+			sourceTree = "<group>";
+		};
+		F473280A2B16F707000849B1 /* Result */ = {
+			isa = PBXGroup;
+			children = (
+				F47327FF2B16F0FD000849B1 /* RPSResult.swift */,
+				F47328012B16F114000849B1 /* MJBResult.swift */,
+			);
+			path = Result;
+			sourceTree = "<group>";
+		};
+		F473280D2B16F765000849B1 /* IO */ = {
+			isa = PBXGroup;
+			children = (
+				F47327D12B1589E3000849B1 /* IO.swift */,
+				F473280B2B16F755000849B1 /* Console.swift */,
+			);
+			path = IO;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -119,7 +210,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F47327E42B15C4F9000849B1 /* RPSPlayable.swift in Sources */,
+				F47327F62B160B71000849B1 /* MJBGame.swift in Sources */,
+				F47327FC2B1612B2000849B1 /* MJBGesture.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
+				F47328062B16F13A000849B1 /* MJBPart.swift in Sources */,
+				F47327F22B160737000849B1 /* UserPlayer.swift in Sources */,
+				F47328002B16F0FD000849B1 /* RPSResult.swift in Sources */,
+				F47327EC2B160687000849B1 /* RPSGesture.swift in Sources */,
+				F47327E62B15C7B8000849B1 /* RPSGame.swift in Sources */,
+				F473280C2B16F755000849B1 /* Console.swift in Sources */,
+				F47327D22B1589E3000849B1 /* IO.swift in Sources */,
+				F47328022B16F114000849B1 /* MJBResult.swift in Sources */,
+				F47328042B16F128000849B1 /* RPSPart.swift in Sources */,
+				F47327D42B1589F1000849B1 /* Hand.swift in Sources */,
+				F47327E22B158A5E000849B1 /* HandGameApp.swift in Sources */,
+				F47327E02B158A49000849B1 /* HandGameError.swift in Sources */,
+				F47327F42B160749000849B1 /* ComputerPlayer.swift in Sources */,
+				F47327F82B160E21000849B1 /* MJBPlayable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors/Decision/MJBGesture.swift
+++ b/RockPaperScissors/RockPaperScissors/Decision/MJBGesture.swift
@@ -1,0 +1,13 @@
+//
+//  MJBGesture.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+struct MJBGesture {
+    let hand: Hand
+    let owner: MJBPlayable
+}

--- a/RockPaperScissors/RockPaperScissors/Decision/RPSGesture.swift
+++ b/RockPaperScissors/RockPaperScissors/Decision/RPSGesture.swift
@@ -1,0 +1,13 @@
+//
+//  Gesture.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+struct RPSGesture {
+    let hand: Hand
+    let owner: RPSPlayable
+}

--- a/RockPaperScissors/RockPaperScissors/Game/MJBGame.swift
+++ b/RockPaperScissors/RockPaperScissors/Game/MJBGame.swift
@@ -1,0 +1,61 @@
+//
+//  MJBGame.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+struct MJBGame {
+    private let leftPlayer: MJBPlayable
+    
+    private let rightPlayer: MJBPlayable
+    
+    private var turn: MJBPlayable
+    
+    private var other: MJBPlayable {
+        return self.turn === leftPlayer ? rightPlayer : leftPlayer
+    }
+    
+    init?(rpsWinner: RPSPlayable,rpsLoser: RPSPlayable) {
+        guard let turn = rpsWinner as? MJBPlayable,
+              let other = rpsLoser as? MJBPlayable else { return nil }
+        self.turn = turn
+        self.leftPlayer = self.turn
+        self.rightPlayer = other
+    }
+    
+    private func getPlayerGestures() throws -> (MJBGesture, MJBGesture) {
+        let turnGesture = try turn.makeMJBGesture(currentTurn: self.turn)
+        let otherGesture = try other.makeMJBGesture(currentTurn: self.turn)
+        return (turnGesture, otherGesture)
+    }
+    
+    private func displayResult(_ result: MJBResult) {
+        [leftPlayer, rightPlayer].forEach { player in
+            if let displayablePlayer = player as? MJBResultDisplayable {
+                displayablePlayer.display(result: result)
+            }
+        }
+    }
+    
+    private mutating func changeTurn(to nextTurn: MJBPlayable) {
+        self.turn = nextTurn
+    }
+    
+    mutating func start() throws {
+        while true {
+            let (turnGesture, otherGesture) = try getPlayerGestures()
+            let result = MJBPart(turn: turnGesture, other: otherGesture).getResult()
+            displayResult(result)
+            switch result {
+            case .win:
+                return
+            case .regame(let nextTurn):
+                changeTurn(to: nextTurn)
+                continue
+            }
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Game/MJBPart.swift
+++ b/RockPaperScissors/RockPaperScissors/Game/MJBPart.swift
@@ -1,0 +1,31 @@
+//
+//  MJBPart.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/29/23.
+//
+
+import Foundation
+
+struct MJBPart {
+    private let turn: MJBGesture
+    private let other: MJBGesture
+    
+    init(turn: MJBGesture, other: MJBGesture) {
+        self.turn = turn
+        self.other = other
+    }
+    
+    func getResult() -> MJBResult {
+        let turnHand = turn.hand
+        let otherHand = other.hand
+        
+        if turnHand == otherHand {
+            return .win(winner: turn.owner)
+        } else {
+            let winningGesture = turnHand.wins(otherHand) ? turn : other
+            let nextTurn = winningGesture.owner
+            return .regame(nextTurn: nextTurn)
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Game/RPSGame.swift
+++ b/RockPaperScissors/RockPaperScissors/Game/RPSGame.swift
@@ -1,0 +1,48 @@
+//
+//  RPSGame.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+struct RPSGame {
+    private let leftPlayer: RPSPlayable
+    
+    private let rightPlayer: RPSPlayable
+    
+    init(between leftPlayer: RPSPlayable, and rightPlayer: RPSPlayable) { 
+        self.leftPlayer = leftPlayer
+        self.rightPlayer = rightPlayer
+    }
+    
+    private func getPlayerGestures() throws -> (RPSGesture, RPSGesture) {
+        let leftGesture = try leftPlayer.makeRPSGesture()
+        let rightGesture = try rightPlayer.makeRPSGesture()
+        return (leftGesture, rightGesture)
+    }
+    
+    private func displayResult(_ result: RPSResult) {
+        [leftPlayer, rightPlayer].forEach { player in
+            if let displayablePlayer = player as? RPSResultDisplayable {
+                displayablePlayer.display(result: result)
+            }
+        }
+    }
+    
+    func start() throws -> (winner: RPSPlayable, loser: RPSPlayable) {
+        while true {
+            let (leftGesture, rightGesture) = try getPlayerGestures()
+            let result = RPSPart(between: leftGesture, and: rightGesture).getResult()
+            displayResult(result)
+            switch result {
+            case .win(let winner):
+                let loser = winner === leftPlayer ? rightPlayer : leftPlayer
+                return (winner, loser)
+            case .draw:
+                continue
+            }
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Game/RPSPart.swift
+++ b/RockPaperScissors/RockPaperScissors/Game/RPSPart.swift
@@ -1,0 +1,32 @@
+//
+//  RPSPart.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/29/23.
+//
+
+import Foundation
+
+struct RPSPart {
+    private let leftGesture: RPSGesture
+    
+    private let rightGesture: RPSGesture
+    
+    init(between leftGesture: RPSGesture, and rightGesture: RPSGesture) {
+        self.leftGesture = leftGesture
+        self.rightGesture = rightGesture
+    }
+    
+    func getResult() -> RPSResult {
+        let leftHand = leftGesture.hand
+        let rightHand = rightGesture.hand
+        
+        if leftHand == rightHand {
+            return .draw
+        } else {
+            let winningGesture = leftHand.wins(rightHand) ? leftGesture : rightGesture
+            let winner = winningGesture.owner
+            return .win(winner)
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Hand.swift
+++ b/RockPaperScissors/RockPaperScissors/Hand.swift
@@ -1,0 +1,47 @@
+//
+//  Hand.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+enum Hand: CaseIterable {
+    case rock
+    case paper
+    case scissor
+    
+    static func randomize() -> Self {
+        Hand.allCases.randomElement() ?? .rock
+    }
+    
+    init?(rpsNumber: Int) {
+        switch rpsNumber {
+        case 1: self = .scissor
+        case 2: self = .rock
+        case 3: self = .paper
+        default: return nil
+        }
+    }
+    
+    init?(mjbNumber: Int) {
+        switch mjbNumber {
+        case 1: self = .rock
+        case 2: self = .scissor
+        case 3: self = .paper
+        default: return nil
+        }
+    }
+    
+    func wins(_ counter: Hand) -> Bool {
+        switch self {
+        case .rock:
+            return counter == .scissor
+        case .paper:
+            return counter == .rock
+        case .scissor:
+            return counter == .paper
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/HandGameApp.swift
+++ b/RockPaperScissors/RockPaperScissors/HandGameApp.swift
@@ -1,0 +1,38 @@
+//
+//  HandGameApp.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+struct HandGameApp {
+    private let errorDisplay: HandGameErrorDisplayble
+    
+    init(errorDisplay: HandGameErrorDisplayble) {
+        self.errorDisplay = errorDisplay
+    }
+    
+    private func prepareUsers() -> (HandGamePlayable, HandGamePlayable) {
+        let leftPlayer: HandGamePlayable = UserPlayer(io: console, name: "에피")
+        let rightPlayer: HandGamePlayable = ComputerPlayer()
+        return (leftPlayer, rightPlayer)
+    }
+    
+    private func startGame(with leftPlayer: HandGamePlayable, and rightPlayer: HandGamePlayable) {
+        do {
+            let rpsGame = RPSGame(between: leftPlayer, and: rightPlayer)
+            let (rpsWinner, rpsLoser) = try rpsGame.start()
+            guard var mjbGame = MJBGame(rpsWinner: rpsWinner, rpsLoser: rpsLoser) else { return }
+            try mjbGame.start()
+        } catch HandGameError.someoneWantsToExit {
+            errorDisplay.displayRPSError(HandGameError.someoneWantsToExit)
+        } catch { return }
+    }
+    
+    func run() {
+        let playerDuo = prepareUsers()
+        startGame(with: playerDuo.0, and: playerDuo.1)
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/HandGameError.swift
+++ b/RockPaperScissors/RockPaperScissors/HandGameError.swift
@@ -1,0 +1,20 @@
+//
+//  HandGameError.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+enum HandGameError: Error {
+    case invalidInput
+    case someoneWantsToExit
+    
+    var description: String {
+        switch self {
+        case .invalidInput: return "잘못된 입력입니다. 다시 시도해주세요."
+        case .someoneWantsToExit: return "게임 종료"
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/IO/Console.swift
+++ b/RockPaperScissors/RockPaperScissors/IO/Console.swift
@@ -1,0 +1,35 @@
+//
+//  Console.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/29/23.
+//
+
+import Foundation
+
+final class Console: InputGettable {
+    func getInput() throws -> String {
+        guard let pureInput = readLine() else { throw HandGameError.invalidInput }
+        let refinedInput = pureInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard refinedInput.isEmpty == false else { throw HandGameError.invalidInput }
+        return refinedInput
+    }
+}
+
+extension Console: PromptDisplayable {
+    func displayPrompt(_ prompt: String) {
+        print(prompt, terminator: " ")
+    }
+}
+
+extension Console: OuputDisplayble {
+    func displayOutput(_ output: String) {
+        print(output)
+    }
+}
+
+extension Console: HandGameErrorDisplayble {
+    func displayRPSError(_ error: HandGameError) {
+        print(error.description)
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/IO/IO.swift
+++ b/RockPaperScissors/RockPaperScissors/IO/IO.swift
@@ -1,0 +1,26 @@
+//
+//  IO.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+protocol PromptDisplayable {
+    func displayPrompt(_ prompt: String)
+}
+
+protocol InputGettable {
+    func getInput() throws -> String
+}
+
+protocol OuputDisplayble {
+    func displayOutput(_ output: String)
+}
+
+protocol HandGameErrorDisplayble {
+    func displayRPSError(_ error: HandGameError)
+}
+
+typealias IO = InputGettable & PromptDisplayable & OuputDisplayble & HandGameErrorDisplayble

--- a/RockPaperScissors/RockPaperScissors/Player/ComputerPlayer.swift
+++ b/RockPaperScissors/RockPaperScissors/Player/ComputerPlayer.swift
@@ -1,0 +1,28 @@
+//
+//  ComputerPlayer.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+final class ComputerPlayer: HandGamePlayable {
+    let name = "컴퓨터"
+    
+    func makeRPSGesture() throws -> RPSGesture {
+        let hand = Hand.randomize()
+        return RPSGesture(hand: hand, owner: self)
+    }
+    
+    func makeMJBGesture(currentTurn: MJBPlayable) throws -> MJBGesture {
+        let hand = Hand.randomize()
+        return MJBGesture(hand: hand, owner: self)
+    }
+}
+
+extension ComputerPlayer: CallablePlayer {
+    func getName() -> String {
+        return self.name
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Player/MJBPlayable.swift
+++ b/RockPaperScissors/RockPaperScissors/Player/MJBPlayable.swift
@@ -1,0 +1,20 @@
+//
+//  MJBPlayable.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+protocol MJBPlayable: AnyObject, CallablePlayer {
+    func makeMJBGesture(currentTurn: MJBPlayable) throws -> MJBGesture
+}
+
+protocol MJBResultDisplayable {
+    func display(result: MJBResult)
+}
+
+protocol CallablePlayer {
+    var name: String { get }
+}

--- a/RockPaperScissors/RockPaperScissors/Player/RPSPlayable.swift
+++ b/RockPaperScissors/RockPaperScissors/Player/RPSPlayable.swift
@@ -1,0 +1,18 @@
+//
+//  Playable.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+protocol RPSPlayable: AnyObject {
+    func makeRPSGesture() throws -> RPSGesture
+}
+
+protocol RPSResultDisplayable {
+    func display(result: RPSResult)
+}
+
+typealias HandGamePlayable = RPSPlayable & MJBPlayable

--- a/RockPaperScissors/RockPaperScissors/Player/UserPlayer.swift
+++ b/RockPaperScissors/RockPaperScissors/Player/UserPlayer.swift
@@ -1,0 +1,105 @@
+//
+//  UserPlayer.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/28/23.
+//
+
+import Foundation
+
+final class UserPlayer {
+    let name: String
+    
+    private let io: IO
+    
+    init(io: IO, name: String) {
+        self.io = io
+        self.name = name
+    }
+    
+    private func getNumber() throws -> Int {
+        let inputString = try io.getInput()
+        guard let number = Int(inputString) else { throw HandGameError.invalidInput }
+        return number
+    }
+    
+    private func getRPSGesture() throws -> RPSGesture {
+        io.displayPrompt("\(self.name) - 가위(1), 바위(2), 보(3)! <종료 : 0> :")
+        let number = try getNumber()
+        if let hand = Hand(rpsNumber: number) {
+            return RPSGesture(hand: hand, owner: self)
+        } else if number == 0 {
+            throw HandGameError.someoneWantsToExit
+        } else {
+            throw HandGameError.invalidInput
+        }
+    }
+    
+    private func getMJBGesture(currentTurn: MJBPlayable) throws -> MJBGesture {
+        io.displayPrompt("[\(currentTurn.name) 턴] \(self.name) - 묵(1), 찌(2), 빠(3)! <종료 : 0> :")
+        let number = try getNumber()
+        if let hand = Hand(mjbNumber: number) {
+            return MJBGesture(hand: hand, owner: self)
+        } else if number == 0 {
+            throw HandGameError.someoneWantsToExit
+        } else {
+            throw HandGameError.invalidInput
+        }
+    }
+}
+
+// MARK: - RPSPlayable
+extension UserPlayer: RPSPlayable {
+    func makeRPSGesture() throws -> RPSGesture {
+        while true {
+            do {
+                return try getRPSGesture()
+            } catch HandGameError.invalidInput {
+                io.displayRPSError(HandGameError.invalidInput)
+                continue
+            } catch { throw error }
+        }
+    }
+}
+
+// MARK: - MJBPlayable
+extension UserPlayer: MJBPlayable {
+    func makeMJBGesture(currentTurn: MJBPlayable) throws -> MJBGesture {
+        while true {
+            do {
+                return try getMJBGesture(currentTurn: currentTurn)
+            } catch HandGameError.invalidInput {
+                io.displayRPSError(HandGameError.invalidInput)
+                continue
+            } catch { throw error }
+        }
+    }
+}
+
+// MARK: - RPSResultDisplayable
+extension UserPlayer: RPSResultDisplayable {
+    func display(result: RPSResult) {
+        let message: String
+        switch result {
+        case .win(let winner):
+            message = (winner === self) ? "이겼습니다!" : "졌습니다!"
+        case .draw:
+            message = "비겼습니다!"
+        }
+        io.displayOutput(message)
+    }
+}
+
+// MARK: - CallablePlayer
+extension UserPlayer: CallablePlayer {
+    func getName() -> String {
+        return self.name
+    }
+}
+
+// MARK: - MJBResultDisplayable
+extension UserPlayer: MJBResultDisplayable {
+    func display(result: MJBResult) {
+        io.displayOutput(result.description)
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Result/MJBResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Result/MJBResult.swift
@@ -1,0 +1,24 @@
+//
+//  MJBResult.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/29/23.
+//
+
+import Foundation
+
+enum MJBResult {
+    case win(winner: MJBPlayable)
+    case regame(nextTurn: MJBPlayable)
+    
+    var description: String {
+        switch self {
+        case .win(let winner):
+            let winnerName = winner.name
+            return "\(winnerName)의 승리!"
+        case .regame(let nextTurn):
+            let nextTurnName = nextTurn.name
+            return "\(nextTurnName)의 턴입니다."
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Result/RPSResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Result/RPSResult.swift
@@ -1,0 +1,13 @@
+//
+//  RPSResult.swift
+//  RockPaperScissors
+//
+//  Created by Effie on 11/29/23.
+//
+
+import Foundation
+
+enum RPSResult {
+    case win(RPSPlayable)
+    case draw
+}

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -2,9 +2,9 @@
 //  RockPaperScissors - main.swift
 //  Created by tacocat.
 //  Copyright © tastycode. All rights reserved.
-// 
+//
 
 import Foundation
 
-print("Hello, World!")
-
+let console = Console()
+HandGameApp(errorDisplay: console).run()


### PR DESCRIPTION
## 설계 설명

### HandGameApp

- 앱은 플레이어를 입력 받아 가위바위보 게임과 묵찌빠 게임을 진행합니다.
- 생성 시 에러를 표시할 수 있는 객체를 전달받아 게임 진행 중 발생한 에러(예외) 관련 메시지를 출력합니다.

### RPSGame, MJBGame

- 각 게임 구조체는 게임을 진행할 두 명의 플레이어로 생성됩니다.
- 게임은 루프를 돌며 각 게임의 Part 게임을 진행합니다.
- Game은 두 플레이어(RPSPlayable)로부터 Gesture 를 생성해 Part 게임을 진행하고, Part 게임의 결과를 각 플레이어(RPSResultDisplayable)가 출력하도록 합니다.

### RPSPart, MJBPart

- 각 게임의 Part 게임은 플레이어 두 명의 Gesture을 가지고 생성됩니다.
- **Gesture**는 플레이어가 제출한 Hand와, Hand를 제출한 플레이어 정보로 구성되어 있습니다.
- Part 는 전달받은 Hand 를 가지고 파트 게임 결과를 판정해, 게임 결과와 게임의 승자 정보를 표현하는 **RPSResult** 타입을 반환합니다.

### UserPlayer

사용자 플레이어는 다음의 기능을 가진 플레이어입니다.

- RPSPlayable, MJBPlayable
    
    가위바위보 게임을 위해 Gesture를 제출할 수 있습니다.
    
- RPSResultDisplayable, MJBResultDisplayable
    
    가위바위보와 묵찌빠 게임의 결과를 출력할 수 있습니다.
    
    **ComputerPlayer**는 UserPlayer와 다르게 ResultDisplayable을 구현하고 있지 않기 때문에 결과를 출력할 수 없습니다.
    
- CallablePlayer
    
    묵찌빠 게임에서 각 플레이어가 현재 Game의 turn을 출력할 때 필요한 이름을 가지고 있습니다.
    

### Console

입출력을 받는 console은 다음의 기능을 가지고 있습니다.

- InputGettable
    
    실제 콘솔로부터 사용자 입력을 받아 가공해서 리턴합니다.
    
- PromptDisplayable
    
    콘솔에 전달된 프롬프트 문자열을 출력할 수 있습니다.
    
- OuputDisplayble
    
    콘솔에 결과 문자열을 출력할 수 있습니다.
    
- HandGameErrorDisplayble
    
    콘솔에 전달된 에러의 메시지를 출력할 수 있습니다.